### PR TITLE
Add partitioner to producer context

### DIFF
--- a/src/producer/base_producer.rs
+++ b/src/producer/base_producer.rs
@@ -258,6 +258,7 @@ where
                 //partitioner
                 null_mut()
             },
+            // todo: clleanup partitioner when producer is dropped.
             Some(partitioner) => Arc::into_raw(partitioner) as *mut c_void,
         };
 

--- a/src/producer/base_producer.rs
+++ b/src/producer/base_producer.rs
@@ -230,7 +230,7 @@ unsafe extern "C" fn partitioner_cb<C: ProducerContext>(
         Some(unsafe { slice::from_raw_parts(keydata as *const u8, keylen) })
     };
 
-    let producer_context = &mut *(rkt_opaque as *mut C::Part);
+    let producer_context = &mut *(rkt_opaque as *mut C::CustomPartitioner);
     return producer_context.partition(name, key, partition_cnt, is_partition_available);
 }
 
@@ -250,7 +250,7 @@ where
     fn from_config_and_context(config: &ClientConfig, context: C) -> KafkaResult<BaseProducer<C>> {
         let native_config = config.create_native_config()?;
 
-        let partitioner = match context.get_partitioner() {
+        let partitioner = match context.get_custom_partitioner() {
             None => {
                 // todo: for tests only
                 //let partitioner = Box::new(TestPartitioner {});

--- a/src/producer/base_producer.rs
+++ b/src/producer/base_producer.rs
@@ -44,7 +44,7 @@
 use std::ffi::{CString, CStr};
 use std::mem;
 use std::os::raw::c_void;
-use std::ptr;
+use std::ptr::{self, null, null_mut};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::thread::{self, JoinHandle};
@@ -247,10 +247,11 @@ where
         let partitioner = match context.get_partitioner() {
             None => {
                 // todo: for tests only
-                let partitioner = Box::new(TestPartitioner {});
-                let partitioner = Box::into_raw(partitioner) as *mut c_void;
-                partitioner
-            }
+                //let partitioner = Box::new(TestPartitioner {});
+                //let partitioner = Box::into_raw(partitioner) as *mut c_void;
+                //partitioner
+                null_mut()
+            },
             Some(partitioner) => Arc::into_raw(partitioner) as *mut c_void,
         };
 

--- a/src/producer/base_producer.rs
+++ b/src/producer/base_producer.rs
@@ -44,7 +44,7 @@
 use std::ffi::{CString, CStr};
 use std::mem;
 use std::os::raw::c_void;
-use std::ptr::{self, null, null_mut};
+use std::ptr::{self, null_mut};
 use std::slice;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;

--- a/src/producer/future_producer.rs
+++ b/src/producer/future_producer.rs
@@ -167,11 +167,11 @@ impl<C: ClientContext + 'static> ClientContext for FutureProducerContext<C> {
     }
 }
 
-use crate::producer::TestPartitioner;
+use crate::producer::NoCustomPartitioner;
 
 impl<C: ClientContext + 'static> ProducerContext for FutureProducerContext<C> {
     type DeliveryOpaque = Box<oneshot::Sender<OwnedDeliveryResult>>;
-    type Part = TestPartitioner;
+    type Part = NoCustomPartitioner;
 
     fn delivery(
         &self,
@@ -426,7 +426,7 @@ mod tests {
     impl ClientContext for TestContext {}
     impl ProducerContext for TestContext {
         type DeliveryOpaque = Box<i32>;
-        type Part = TestPartitioner;
+        type Part = NoCustomPartitioner;
 
         fn delivery(&self, _: &DeliveryResult<'_>, _: Self::DeliveryOpaque) {
             unimplemented!()

--- a/src/producer/future_producer.rs
+++ b/src/producer/future_producer.rs
@@ -167,8 +167,11 @@ impl<C: ClientContext + 'static> ClientContext for FutureProducerContext<C> {
     }
 }
 
+use crate::producer::TestPartitioner;
+
 impl<C: ClientContext + 'static> ProducerContext for FutureProducerContext<C> {
     type DeliveryOpaque = Box<oneshot::Sender<OwnedDeliveryResult>>;
+    type Part = TestPartitioner;
 
     fn delivery(
         &self,

--- a/src/producer/future_producer.rs
+++ b/src/producer/future_producer.rs
@@ -426,6 +426,7 @@ mod tests {
     impl ClientContext for TestContext {}
     impl ProducerContext for TestContext {
         type DeliveryOpaque = Box<i32>;
+        type Part = TestPartitioner;
 
         fn delivery(&self, _: &DeliveryResult<'_>, _: Self::DeliveryOpaque) {
             unimplemented!()

--- a/src/producer/future_producer.rs
+++ b/src/producer/future_producer.rs
@@ -171,7 +171,7 @@ use crate::producer::NoCustomPartitioner;
 
 impl<C: ClientContext + 'static> ProducerContext for FutureProducerContext<C> {
     type DeliveryOpaque = Box<oneshot::Sender<OwnedDeliveryResult>>;
-    type Part = NoCustomPartitioner;
+    type CustomPartitioner = NoCustomPartitioner;
 
     fn delivery(
         &self,
@@ -426,7 +426,7 @@ mod tests {
     impl ClientContext for TestContext {}
     impl ProducerContext for TestContext {
         type DeliveryOpaque = Box<i32>;
-        type Part = NoCustomPartitioner;
+        type CustomPartitioner = NoCustomPartitioner;
 
         fn delivery(&self, _: &DeliveryResult<'_>, _: Self::DeliveryOpaque) {
             unimplemented!()

--- a/src/producer/mod.rs
+++ b/src/producer/mod.rs
@@ -207,7 +207,7 @@ pub trait ProducerContext: ClientContext {
     /// when calling send.
     fn delivery(&self, delivery_result: &DeliveryResult<'_>, delivery_opaque: Self::DeliveryOpaque);
 
-    /// todo
+    /// This method is called when creating producer in order to register custom partitioner.
     fn get_custom_partitioner(&self) -> Option<Arc<Self::CustomPartitioner>> {
         None
     }
@@ -231,7 +231,7 @@ pub trait Partitioner {
 
 /// Partitioner used when no custom partitioner is needed.
 /// Needed as associated type defaults are unsable (https://github.com/rust-lang/rust/issues/29661) so
-/// it can't be set as default for ProducerContext::Part for now.
+/// it can't be set as default for ProducerContext::CustomPartitioner for now.
 pub struct NoCustomPartitioner {}
 
 impl Partitioner for NoCustomPartitioner {

--- a/src/producer/mod.rs
+++ b/src/producer/mod.rs
@@ -195,7 +195,11 @@ pub trait ProducerContext: ClientContext {
     /// method once the message has been delivered, or failed to.
     type DeliveryOpaque: IntoOpaque;
 
-    /// todo
+    /// Partitioner is a user-defined structure that will called
+    /// when deciding to which partition send a message to.
+    ///
+    /// Associated type defaults are unstable (https://github.com/rust-lang/rust/issues/29661) so
+    /// for now it isn't possible to set it to NoCustomPartitioner.
     type Part: Partitioner;
 
     /// This method will be called once the message has been delivered (or
@@ -224,10 +228,12 @@ pub trait Partitioner {
     ) -> i32;
 }
 
-/// todo
-pub struct TestPartitioner {}
+/// Partitioner used when no custom partitioner is needed.
+/// Needed as associated type defaults are unsable (https://github.com/rust-lang/rust/issues/29661) so
+/// it can't be set as default for ProducerContext::Part for now.
+pub struct NoCustomPartitioner {}
 
-impl Partitioner for TestPartitioner {
+impl Partitioner for NoCustomPartitioner {
     fn partition(
         &self,
         _topic_name: &str,
@@ -235,7 +241,7 @@ impl Partitioner for TestPartitioner {
         _partition_cnt: i32,
         _is_paritition_available: impl Fn(i32) -> bool,
     ) -> i32 {
-        15
+        panic!("NoCustomPartitioner should not be called");
     }
 }
 
@@ -248,7 +254,7 @@ pub struct DefaultProducerContext;
 impl ClientContext for DefaultProducerContext {}
 impl ProducerContext for DefaultProducerContext {
     type DeliveryOpaque = ();
-    type Part = TestPartitioner;
+    type Part = NoCustomPartitioner;
 
     fn delivery(&self, _: &DeliveryResult<'_>, _: Self::DeliveryOpaque) {}
 }

--- a/src/producer/mod.rs
+++ b/src/producer/mod.rs
@@ -208,7 +208,7 @@ pub trait ProducerContext: ClientContext {
     fn delivery(&self, delivery_result: &DeliveryResult<'_>, delivery_opaque: Self::DeliveryOpaque);
 
     /// This method is called when creating producer in order to register custom partitioner.
-    fn get_custom_partitioner(&self) -> Option<Arc<Self::CustomPartitioner>> {
+    fn get_custom_partitioner(&self) -> Option<&Self::CustomPartitioner> {
         None
     }
 }

--- a/src/producer/mod.rs
+++ b/src/producer/mod.rs
@@ -218,6 +218,7 @@ pub trait Partitioner {
     /// Return partition to use for `topic_name`.
     /// `topic_name` is the name of a topic to which a message is being produced.
     /// `partition_cnt` is the number of partitions for this topic.
+    /// `key` is an optional key of the message.
     /// `is_partition_available` is a function that can be called to check if a partition has an active leader broker.
     fn partition(
         &self,

--- a/src/producer/mod.rs
+++ b/src/producer/mod.rs
@@ -218,6 +218,7 @@ pub trait Partitioner {
     fn partition(
         &self,
         topic_name: &str,
+        key: Option<&[u8]>,
         partition_cnt: i32,
         is_partition_available: impl Fn(i32) -> bool,
     ) -> i32;
@@ -230,6 +231,7 @@ impl Partitioner for TestPartitioner {
     fn partition(
         &self,
         _topic_name: &str,
+        _key: Option<&[u8]>,
         _partition_cnt: i32,
         _is_paritition_available: impl Fn(i32) -> bool,
     ) -> i32 {

--- a/src/producer/mod.rs
+++ b/src/producer/mod.rs
@@ -220,6 +220,13 @@ pub trait Partitioner {
     /// `partition_cnt` is the number of partitions for this topic.
     /// `key` is an optional key of the message.
     /// `is_partition_available` is a function that can be called to check if a partition has an active leader broker.
+    ///
+    /// It may be called in any thread at any time,
+    /// It may be called multiple times for the same message/key.
+    /// MUST NOT block or execute for prolonged periods of time.
+    /// MUST return a value between 0 and partition_cnt-1, or the
+    /// special RD_KAFKA_PARTITION_UA value if partitioning could not be performed.
+    /// See documentation for rd_kafka_topic_conf_set_partitioner_cb from librdkafka for more info.
     fn partition(
         &self,
         topic_name: &str,

--- a/src/producer/mod.rs
+++ b/src/producer/mod.rs
@@ -200,7 +200,7 @@ pub trait ProducerContext: ClientContext {
     ///
     /// Associated type defaults are unstable (https://github.com/rust-lang/rust/issues/29661) so
     /// for now it isn't possible to set it to NoCustomPartitioner.
-    type Part: Partitioner;
+    type CustomPartitioner: Partitioner;
 
     /// This method will be called once the message has been delivered (or
     /// failed to). The `DeliveryOpaque` will be the one provided by the user
@@ -208,7 +208,7 @@ pub trait ProducerContext: ClientContext {
     fn delivery(&self, delivery_result: &DeliveryResult<'_>, delivery_opaque: Self::DeliveryOpaque);
 
     /// todo
-    fn get_partitioner(&self) -> Option<Arc<Self::Part>> {
+    fn get_custom_partitioner(&self) -> Option<Arc<Self::CustomPartitioner>> {
         None
     }
 }
@@ -255,7 +255,7 @@ pub struct DefaultProducerContext;
 impl ClientContext for DefaultProducerContext {}
 impl ProducerContext for DefaultProducerContext {
     type DeliveryOpaque = ();
-    type Part = NoCustomPartitioner;
+    type CustomPartitioner = NoCustomPartitioner;
 
     fn delivery(&self, _: &DeliveryResult<'_>, _: Self::DeliveryOpaque) {}
 }

--- a/tests/test_low_producers.rs
+++ b/tests/test_low_producers.rs
@@ -13,7 +13,7 @@ use rdkafka::config::ClientConfig;
 use rdkafka::error::{KafkaError, RDKafkaErrorCode};
 use rdkafka::message::{Header, Headers, Message, OwnedHeaders, OwnedMessage};
 use rdkafka::producer::{
-    BaseProducer, BaseRecord, DeliveryResult, Producer, ProducerContext, ThreadedProducer,
+    BaseProducer, BaseRecord, DeliveryResult, Producer, ProducerContext, ThreadedProducer, TestPartitioner,
 };
 use rdkafka::types::RDKafkaRespErr;
 use rdkafka::util::current_time_millis;
@@ -37,6 +37,7 @@ impl ClientContext for PrintingContext {
 
 impl ProducerContext for PrintingContext {
     type DeliveryOpaque = usize;
+    type Part = TestPartitioner;
 
     fn delivery(&self, delivery_result: &DeliveryResult, delivery_opaque: Self::DeliveryOpaque) {
         println!("Delivery: {:?} {:?}", delivery_result, delivery_opaque);
@@ -70,6 +71,7 @@ impl ClientContext for CollectingContext {
 
 impl ProducerContext for CollectingContext {
     type DeliveryOpaque = usize;
+    type Part = TestPartitioner;
 
     fn delivery(&self, delivery_result: &DeliveryResult, delivery_opaque: Self::DeliveryOpaque) {
         let mut results = self.results.lock().unwrap();
@@ -211,6 +213,7 @@ impl ClientContext for HeaderCheckContext {}
 
 impl ProducerContext for HeaderCheckContext {
     type DeliveryOpaque = usize;
+    type Part = TestPartitioner;
 
     fn delivery(&self, delivery_result: &DeliveryResult, message_id: usize) {
         let message = delivery_result.as_ref().unwrap();
@@ -356,6 +359,7 @@ fn test_base_producer_opaque_arc() -> Result<(), Box<dyn Error>> {
 
     impl ProducerContext for OpaqueArcContext {
         type DeliveryOpaque = Arc<Mutex<usize>>;
+        type Part = TestPartitioner;
 
         fn delivery(&self, _: &DeliveryResult, opaque: Self::DeliveryOpaque) {
             let mut shared_count = opaque.lock().unwrap();

--- a/tests/test_low_producers.rs
+++ b/tests/test_low_producers.rs
@@ -13,7 +13,7 @@ use rdkafka::config::ClientConfig;
 use rdkafka::error::{KafkaError, RDKafkaErrorCode};
 use rdkafka::message::{Header, Headers, Message, OwnedHeaders, OwnedMessage};
 use rdkafka::producer::{
-    BaseProducer, BaseRecord, DeliveryResult, Producer, ProducerContext, ThreadedProducer, TestPartitioner,
+    BaseProducer, BaseRecord, DeliveryResult, Producer, ProducerContext, ThreadedProducer, NoCustomPartitioner,
 };
 use rdkafka::types::RDKafkaRespErr;
 use rdkafka::util::current_time_millis;
@@ -37,7 +37,7 @@ impl ClientContext for PrintingContext {
 
 impl ProducerContext for PrintingContext {
     type DeliveryOpaque = usize;
-    type Part = TestPartitioner;
+    type Part = NoCustomPartitioner;
 
     fn delivery(&self, delivery_result: &DeliveryResult, delivery_opaque: Self::DeliveryOpaque) {
         println!("Delivery: {:?} {:?}", delivery_result, delivery_opaque);
@@ -71,7 +71,7 @@ impl ClientContext for CollectingContext {
 
 impl ProducerContext for CollectingContext {
     type DeliveryOpaque = usize;
-    type Part = TestPartitioner;
+    type Part = NoCustomPartitioner;
 
     fn delivery(&self, delivery_result: &DeliveryResult, delivery_opaque: Self::DeliveryOpaque) {
         let mut results = self.results.lock().unwrap();
@@ -213,7 +213,7 @@ impl ClientContext for HeaderCheckContext {}
 
 impl ProducerContext for HeaderCheckContext {
     type DeliveryOpaque = usize;
-    type Part = TestPartitioner;
+    type Part = NoCustomPartitioner;
 
     fn delivery(&self, delivery_result: &DeliveryResult, message_id: usize) {
         let message = delivery_result.as_ref().unwrap();
@@ -359,7 +359,7 @@ fn test_base_producer_opaque_arc() -> Result<(), Box<dyn Error>> {
 
     impl ProducerContext for OpaqueArcContext {
         type DeliveryOpaque = Arc<Mutex<usize>>;
-        type Part = TestPartitioner;
+        type Part = NoCustomPartitioner;
 
         fn delivery(&self, _: &DeliveryResult, opaque: Self::DeliveryOpaque) {
             let mut shared_count = opaque.lock().unwrap();

--- a/tests/test_low_producers.rs
+++ b/tests/test_low_producers.rs
@@ -37,7 +37,7 @@ impl ClientContext for PrintingContext {
 
 impl ProducerContext for PrintingContext {
     type DeliveryOpaque = usize;
-    type Part = NoCustomPartitioner;
+    type CustomPartitioner = NoCustomPartitioner;
 
     fn delivery(&self, delivery_result: &DeliveryResult, delivery_opaque: Self::DeliveryOpaque) {
         println!("Delivery: {:?} {:?}", delivery_result, delivery_opaque);
@@ -71,7 +71,7 @@ impl ClientContext for CollectingContext {
 
 impl ProducerContext for CollectingContext {
     type DeliveryOpaque = usize;
-    type Part = NoCustomPartitioner;
+    type CustomPartitioner = NoCustomPartitioner;
 
     fn delivery(&self, delivery_result: &DeliveryResult, delivery_opaque: Self::DeliveryOpaque) {
         let mut results = self.results.lock().unwrap();
@@ -213,7 +213,7 @@ impl ClientContext for HeaderCheckContext {}
 
 impl ProducerContext for HeaderCheckContext {
     type DeliveryOpaque = usize;
-    type Part = NoCustomPartitioner;
+    type CustomPartitioner = NoCustomPartitioner;
 
     fn delivery(&self, delivery_result: &DeliveryResult, message_id: usize) {
         let message = delivery_result.as_ref().unwrap();
@@ -359,7 +359,7 @@ fn test_base_producer_opaque_arc() -> Result<(), Box<dyn Error>> {
 
     impl ProducerContext for OpaqueArcContext {
         type DeliveryOpaque = Arc<Mutex<usize>>;
-        type Part = NoCustomPartitioner;
+        type CustomPartitioner = NoCustomPartitioner;
 
         fn delivery(&self, _: &DeliveryResult, opaque: Self::DeliveryOpaque) {
             let mut shared_count = opaque.lock().unwrap();

--- a/tests/test_low_producers.rs
+++ b/tests/test_low_producers.rs
@@ -138,8 +138,8 @@ impl ProducerContext for ContextWithFixedPartitioner {
         }
     }
 
-    fn get_custom_partitioner(&self) -> Option<Arc<Self::CustomPartitioner>> {
-        return Some(Arc::clone(&self.partitioner));
+    fn get_custom_partitioner(&self) -> Option<&Self::CustomPartitioner> {
+        return Some(&self.partitioner);
     }
 }
 


### PR DESCRIPTION
- [x] Tests
- [x] Get rid of UTF-8 validity check for topic's name during each partitioner call.
- [x] Partitioner cleanup when `BaseProducer` is dropped.